### PR TITLE
Fix createdAt date issue

### DIFF
--- a/backend/src/main/java/com/amodugu/todo_list/entity/Task.java
+++ b/backend/src/main/java/com/amodugu/todo_list/entity/Task.java
@@ -24,4 +24,9 @@ public class Task {
     private boolean completed = false;
 
     private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
 }


### PR DESCRIPTION
Before saving the task to db, it's date field is set to current date.